### PR TITLE
feat: separate recommendation refresh from API startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,17 @@ ES_HOST=http://localhost:9200
 
 ### 4. 필수 인프라 실행
 
-> 서버 시작 시 추천 캐시 초기화를 수행하므로 아래 서비스가 모두 실행 중이어야 합니다.
+> 서버 시작 전에 아래 서비스가 모두 실행 중이어야 하며, 먼저 refresh 스크립트를 실행해야 합니다.
 > 
 - MySQL
 - Redis
 - Elasticsearch
+
+Refresh recommendation data and FAISS-ready assets before starting the API:
+
+```bash
+python scripts/refresh_recommendation.py
+```
 
 ---
 
@@ -221,4 +227,3 @@ http://127.0.0.1:8000/docs
 - 배치 캐싱과 실시간 로그 반영 구조 분리
 - 신규 사용자에 대한 fallback 추천 전략 추가
 - 추천 결과 다양성(diversity) 개선
-

--- a/scripts/refresh_recommendation.py
+++ b/scripts/refresh_recommendation.py
@@ -1,0 +1,14 @@
+from dotenv import load_dotenv
+from pathlib import Path
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+from src.data.cache_initializer import refresh_recommendation_data
+
+
+if __name__ == "__main__":
+    # Batch-style refresh entry point:
+    # 1) load from MySQL / Elasticsearch
+    # 2) cache source datasets in Redis
+    # 3) cache recommender-ready assets in Redis
+    refresh_recommendation_data()

--- a/src/data/cache_initializer.py
+++ b/src/data/cache_initializer.py
@@ -1,7 +1,12 @@
-import redis
+import json
 import os
-import pandas as pd
+
+import numpy as np
+import redis
+from sklearn.preprocessing import normalize
+
 from scripts.download.data_loader import DataLoader
+
 
 class CacheManager:
     def __init__(self):
@@ -9,7 +14,7 @@ class CacheManager:
         self.redis_client = redis.StrictRedis(
             host=os.getenv("REDIS_HOST", "localhost"),
             port=int(os.getenv("REDIS_PORT", 6379)),
-            decode_responses=True
+            decode_responses=True,
         )
 
     def cache_dataframe(self, key, df):
@@ -22,8 +27,68 @@ class CacheManager:
         self.cache_dataframe("df:user_data", self.loader.fetch_user_data_df())
         self.cache_dataframe("df:user_restaurant", self.loader.fetch_user_restaurant_df())
         self.cache_dataframe("df:user_board", self.loader.fetch_user_board_df())
-        print("✅ 모든 DF가 Redis에 캐싱되었습니다.")
+        print("Cached source datasets in Redis.")
+
+    def _load_cached_rows(self, key):
+        json_data = self.redis_client.get(key)
+        if not json_data:
+            return []
+        return json.loads(json_data)
+
+    def _build_tag_vocab(self):
+        tags = set()
+        for key in ("df:user_data", "df:review", "df:restaurant"):
+            for row in self._load_cached_rows(key):
+                for tag_obj in row.get("tags", []):
+                    tags.add(tag_obj["tag_id"])
+        return sorted(tags)
+
+    @staticmethod
+    def _to_vector(tag_vocab, tags):
+        tag_set = set(tags)
+        return np.array([1 if tag in tag_set else 0 for tag in tag_vocab], dtype=np.float32)
+
+    def _build_index_payload(self, redis_key, id_key, tag_vocab):
+        rows = self._load_cached_rows(redis_key)
+        item_ids = []
+        item_vectors = []
+
+        for row in rows:
+            tag_ids = [tag["tag_id"] for tag in row.get("tags", [])]
+            item_ids.append(row[id_key])
+            item_vectors.append(self._to_vector(tag_vocab, tag_ids))
+
+        if not item_vectors:
+            return [], []
+
+        normalized_vectors = normalize(np.array(item_vectors, dtype=np.float32), axis=1)
+        return item_ids, normalized_vectors.tolist()
+
+    def cache_recommendation_assets(self):
+        # Prepare FAISS-ready assets during the refresh step so the API only loads them at startup.
+        tag_vocab = self._build_tag_vocab()
+        post_ids, post_vectors = self._build_index_payload("df:review", "board_id", tag_vocab)
+        restaurant_ids, restaurant_vectors = self._build_index_payload(
+            "df:restaurant", "restaurant_id", tag_vocab
+        )
+
+        self.redis_client.set("rec:tag_vocab", json.dumps(tag_vocab))
+        self.redis_client.set("rec:post_ids", json.dumps(post_ids))
+        self.redis_client.set("rec:post_vectors", json.dumps(post_vectors))
+        self.redis_client.set("rec:restaurant_ids", json.dumps(restaurant_ids))
+        self.redis_client.set("rec:restaurant_vectors", json.dumps(restaurant_vectors))
+        print("Cached recommendation-ready assets in Redis.")
+
+    def refresh_all(self):
+        self.cache_all()
+        self.cache_recommendation_assets()
+
+
+def refresh_recommendation_data():
+    manager = CacheManager()
+    manager.refresh_all()
+
 
 def cache_dataframe_init():
-    manager = CacheManager()
-    manager.cache_all()
+    # Backward-compatible alias for the previous startup-oriented function name.
+    refresh_recommendation_data()

--- a/src/main.py
+++ b/src/main.py
@@ -1,50 +1,51 @@
-from dotenv import load_dotenv
-load_dotenv()
-import os
-import redis
-from fastapi import FastAPI
 from contextlib import asynccontextmanager
-# from src.api import post
-# from src.api import restaurant
+import os
+
+import redis
+from dotenv import load_dotenv
+from fastapi import FastAPI
+
 from src.api import recommend
-from src.data.cache_initializer import cache_dataframe_init
 from src.models.faiss_recommenderation_model import FaissRecommendationModel
+
+
+load_dotenv()
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # 서버 시작 시 실행
-    cache_dataframe_init()
-
     redis_client = redis.StrictRedis(
         host=os.getenv("REDIS_HOST", "127.0.0.1"),
         port=int(os.getenv("REDIS_PORT", 6379)),
-        decode_responses=True
+        decode_responses=True,
     )
     app.state.redis_client = redis_client
+    # Startup only loads recommendation assets that were prepared by the refresh script.
     app.state.recommendation_model = FaissRecommendationModel(redis_client)
 
     try:
-        yield  # 여기서 서버가 실행됨
+        yield
     finally:
         redis_client.connection_pool.disconnect()
+
 
 app = FastAPI(
     title="음식점 추천 API",
     description="다양한 방식의 음식점 추천 서비스를 제공합니다",
     version="1.0.0",
-    lifespan=lifespan
+    lifespan=lifespan,
 )
+
 
 @app.get("/")
 async def root():
     return {"message": "음식점 추천 API에 오신 것을 환영합니다", "version": "1.0.0"}
 
-# app.include_router(post.router)
-# app.include_router(restaurant.router)
+
 app.include_router(recommend.router)
 
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run("src.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/src/models/faiss_recommenderation_model.py
+++ b/src/models/faiss_recommenderation_model.py
@@ -1,56 +1,42 @@
-﻿import math
 import json
+import math
+
+import faiss
 import numpy as np
 from sklearn.preprocessing import normalize
-import faiss
+
 
 class FaissRecommendationModel:
     def __init__(self, rds):
         self.rds = rds
-        self.tag_vocab = self._load_tag_vocab()
-        self.post_index, self.post_ids = self._build_index("df:review", "board_id")
-        self.restaurant_index, self.restaurant_ids = self._build_index("df:restaurant", "restaurant_id")
+        self.tag_vocab = self._load_json("rec:tag_vocab", [])
+        self.post_ids = self._load_json("rec:post_ids", [])
+        self.restaurant_ids = self._load_json("rec:restaurant_ids", [])
+        self.post_index = self._load_index("rec:post_vectors")
+        self.restaurant_index = self._load_index("rec:restaurant_vectors")
 
-    def _load_tag_vocab(self):
-        user_data_json = self.rds.get("df:user_data")
-        review_json = self.rds.get("df:review")
-        restaurant_json = self.rds.get("df:restaurant")
-
-        tags = set()
-        for data in [user_data_json, review_json, restaurant_json]:
-            if not data:
-                continue
-            for row in json.loads(data):
-                for tag_obj in row.get("tags", []):
-                    tags.add(tag_obj["tag_id"])
-        return sorted(tags)
+    def _load_json(self, key, default):
+        json_data = self.rds.get(key)
+        if not json_data:
+            return default
+        return json.loads(json_data)
 
     def _to_vector(self, tags):
-        return np.array([1 if tag in tags else 0 for tag in self.tag_vocab], dtype=np.float32)
+        tag_set = set(tags)
+        return np.array([1 if tag in tag_set else 0 for tag in self.tag_vocab], dtype=np.float32)
 
-    def _build_index(self, redis_key, id_key):
-        json_data = self.rds.get(redis_key)
-        if not json_data:
-            return None, []
+    def _load_index(self, vector_key):
+        if not self.tag_vocab:
+            return None
 
-        data = json.loads(json_data)
-        item_ids = []
-        item_vectors = []
+        vectors = self._load_json(vector_key, [])
+        if not vectors:
+            return None
 
-        for row in data:
-            tag_ids = [tag["tag_id"] for tag in row.get("tags", [])]
-            vec = self._to_vector(tag_ids)
-            item_vectors.append(vec)
-            item_ids.append(row[id_key])
-
-        if not item_vectors:
-            return None, []
-
-        item_vectors = normalize(np.array(item_vectors, dtype=np.float32), axis=1)
+        item_vectors = np.array(vectors, dtype=np.float32)
         index = faiss.IndexFlatIP(len(self.tag_vocab))
         index.add(item_vectors)
-
-        return index, item_ids
+        return index
 
     def get_user_tags(self, user_id: int):
         user_data_json = self.rds.get("df:user_data")
@@ -107,8 +93,13 @@ class FaissRecommendationModel:
         if not user_tags:
             return []
         return self._recommend_from_index(
-            user_tags, self.post_index, self.post_ids,
-            ctr_prefix="board", user_id=user_id, page=page, size=size
+            user_tags,
+            self.post_index,
+            self.post_ids,
+            ctr_prefix="board",
+            user_id=user_id,
+            page=page,
+            size=size,
         )
 
     def recommend_restaurants(self, user_id: int, page: int = 0, size: int = 6):
@@ -116,6 +107,11 @@ class FaissRecommendationModel:
         if not user_tags:
             return []
         return self._recommend_from_index(
-            user_tags, self.restaurant_index, self.restaurant_ids,
-            ctr_prefix="restaurant", user_id=user_id, page=page, size=size
+            user_tags,
+            self.restaurant_index,
+            self.restaurant_ids,
+            ctr_prefix="restaurant",
+            user_id=user_id,
+            page=page,
+            size=size,
         )


### PR DESCRIPTION
## 작업 내용

추천 서버에서 데이터 refresh/build 과정을 API startup에서 분리했습니다.

## 주요 변경 사항

* MySQL / Elasticsearch 기반 데이터 적재 로직을 FastAPI startup에서 제거
* `scripts/refresh_recommendation.py` 배치 스크립트 추가
* 추천 서빙에 필요한 자산(`rec:*`)을 Redis에 미리 생성하도록 변경
* API startup 시 Redis의 준비된 데이터를 기반으로 recommender를 로드하도록 수정

## 개선 효과

* 서버 startup이 가벼워지고 안정성이 향상됨
* MySQL/Elasticsearch 상태에 의존하지 않고 API를 실행 가능
* 데이터 갱신과 API 서빙 책임이 분리됨

## 검증

* refresh 스크립트 실행 후 추천 API 정상 동작 확인
* MySQL/Elasticsearch 중단 상태에서도 API startup 가능 확인

## 비고

* Redis는 여전히 추천 서빙에 필요한 핵심 의존성으로 유지됨
